### PR TITLE
#4677 fix parrse ending last chunk

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -665,6 +665,9 @@ class HttpPayloadParser:
                         # end of stream
                         self.payload.feed_eof()
                         return True, chunk[2:]
+                    elif len(chunk) < 2:
+                        self._chunk_tail = chunk
+                        return False, b''
                     else:
                         self._chunk = ChunkState.PARSE_TRAILERS
 


### PR DESCRIPTION
if last chunk splitted 2 parts data_received(b'0\r\n') & data_received(b'\r\n') seted wrong state PARSE_TRAILERS

<!-- Thank you for your contribution! -->

## What do these changes do?

if last chunk splitted 2 parts data_received(b'0\r\n') & data_received(b'\r\n') state remains PARSE_MAYBE_TRAILERS

## Are there changes in behavior for the user?

No

## Related issue number

#4677

## Checklist

- [ x ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
